### PR TITLE
Add summer 2026 appointments webpage

### DIFF
--- a/sommer_termine/index.html
+++ b/sommer_termine/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Sommertermine 2026</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Sommertermine 2026</h1>
+  <div id="cards-container"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/sommer_termine/readme.md
+++ b/sommer_termine/readme.md
@@ -1,0 +1,17 @@
+# Sommertermine 2026
+
+Diese kleine Webseite zeigt eine Auswahl von Veranstaltungen im Sommer 2026 im Stil von Quartettkarten.
+
+## Nutzung
+
+Öffne die Datei `index.html` in einem Browser deiner Wahl. Beim Überfahren einer Karte mit der Maus wird sie leicht vergrößert, als würde man sie hochheben.
+
+## Struktur
+
+- `index.html` – Einstiegspunkt der Webseite
+- `styles.css` – Gestaltung der Karten und des Layouts
+- `script.js` – Logik zum Erzeugen der Karten aus den Termindaten
+
+## Anforderungen
+
+Die Seite nutzt ausschließlich HTML, CSS und JavaScript ohne zusätzliche Bibliotheken.

--- a/sommer_termine/roadmap.md
+++ b/sommer_termine/roadmap.md
@@ -1,0 +1,10 @@
+# Roadmap
+
+## Version 1.0
+- Anzeige von vier festen Terminen im Sommer 2026
+- Hover-Effekt zum Vergrößern der Karten
+
+## Geplante Erweiterungen
+- Responsive Darstellung für mobile Geräte
+- Möglichkeit zum Laden der Termine aus einer externen Quelle
+- Option zur Filterung nach Monaten

--- a/sommer_termine/script.js
+++ b/sommer_termine/script.js
@@ -1,0 +1,47 @@
+const events = [
+  {
+    title: 'Open-Air Konzert',
+    date: '12. Juni 2026',
+    location: 'Stadtpark',
+    description: 'Ein Abend voller Musik unter freiem Himmel.'
+  },
+  {
+    title: 'Sommerfest',
+    date: '5. Juli 2026',
+    location: 'Marktplatz',
+    description: 'Bunte Stände, Spiele und leckeres Essen.'
+  },
+  {
+    title: 'Strandvolleyball Turnier',
+    date: '16. August 2026',
+    location: 'Seebad',
+    description: 'Teams treten am Strand gegeneinander an.'
+  },
+  {
+    title: 'Herbstlicher Wandertag',
+    date: '20. September 2026',
+    location: 'Bergpfad',
+    description: 'Wanderung durch die ersten Herbstfarben.'
+  }
+];
+
+const container = document.getElementById('cards-container');
+
+function createCard(event) {
+  const card = document.createElement('div');
+  card.className = 'card';
+
+  card.innerHTML = `
+    <h2>${event.title}</h2>
+    <p><strong>Datum:</strong> ${event.date}</p>
+    <p><strong>Ort:</strong> ${event.location}</p>
+    <p>${event.description}</p>
+  `;
+
+  return card;
+}
+
+events.forEach(event => {
+  const card = createCard(event);
+  container.appendChild(card);
+});

--- a/sommer_termine/styles.css
+++ b/sommer_termine/styles.css
@@ -1,0 +1,40 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f0f8ff;
+  text-align: center;
+  margin: 0;
+  padding: 20px;
+}
+
+#cards-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+
+.card {
+  width: 200px;
+  height: 300px;
+  border: 2px solid #333;
+  border-radius: 8px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: scale(1.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.card h2 {
+  font-size: 1.2em;
+  margin: 0 0 10px;
+}
+
+.card p {
+  margin: 4px 0;
+}


### PR DESCRIPTION
## Summary
- Create static webpage to display summer 2026 appointments as quartet-style cards
- Implement hover zoom effect using vanilla JavaScript and CSS transitions
- Document project usage and future enhancements in `readme.md` and `roadmap.md`

## Testing
- `node --version`
- `node --check sommer_termine/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6e916e3708327b9d23a48de327f73