### PR TITLE
Adjust site styling to match mockup aesthetic

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,12 +38,16 @@ function createCard(event) {
   const card = document.createElement('div');
   card.className = 'card';
 
+  const linkMarkup = event.link
+    ? `<p class="card-link"><a href="${event.link}" target="_blank" rel="noopener">${event.link}</a></p>`
+    : '';
+
   card.innerHTML = `
     <h2>${event.title}</h2>
     <p><strong>Datum:</strong> ${event.date}</p>
     <p><strong>Ort:</strong> ${event.location}</p>
     <p>${event.description}</p>
-    <p>${event.link}</p>
+    ${linkMarkup}
   `;
 
   return card;

--- a/styles.css
+++ b/styles.css
@@ -1,40 +1,114 @@
+:root {
+  --background: #e5e4df;
+  --card-surface: #f8f8f5;
+  --text-strong: #2f2922;
+  --text-muted: #6b6156;
+  --shadow-primary: rgba(68, 56, 45, 0.18);
+  --shadow-secondary: rgba(117, 103, 87, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
-  background-color: #fffef5;
-  text-align: center;
+  font-family: "Montserrat", "Helvetica Neue", Arial, sans-serif;
+  background-color: var(--background);
+  color: var(--text-strong);
   margin: 0;
-  padding: 20px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 24px 72px;
+  letter-spacing: 0.02em;
+}
+
+h1 {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: clamp(1.6rem, 3vw + 1rem, 2.6rem);
+  font-weight: 600;
+  margin: 0 0 48px;
+  text-align: center;
 }
 
 #cards-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 20px;
+  width: min(1120px, 100%);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 36px;
 }
 
 .card {
-  width: 200px;
-  height: 300px;
-  border: 2px solid #333;
-  border-radius: 8px;
-  background-color: #fff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  padding: 10px;
+  background-color: var(--card-surface);
+  border-radius: 18px;
+  border: 1px solid rgba(82, 70, 58, 0.08);
+  padding: 32px 28px;
+  text-align: left;
+  box-shadow:
+    0 32px 45px -28px var(--shadow-secondary),
+    0 24px 40px -30px var(--shadow-primary);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .card:hover {
-  transform: scale(1.1);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  cursor: pointer;
+  transform: translateY(-6px);
+  box-shadow:
+    0 40px 55px -26px rgba(60, 47, 36, 0.25),
+    0 28px 45px -28px rgba(104, 90, 74, 0.24);
 }
 
 .card h2 {
-  font-size: 1.2em;
-  margin: 0 0 10px;
+  font-size: 1.3rem;
+  margin: 0 0 22px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
 }
 
 .card p {
-  margin: 4px 0;
+  margin: 8px 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+  font-size: 0.98rem;
+}
+
+.card p strong {
+  color: var(--text-strong);
+  letter-spacing: 0.05em;
+}
+
+.card-link {
+  margin-top: 20px;
+  color: var(--text-strong);
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.card-link a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(82, 70, 58, 0.3);
+  padding-bottom: 2px;
+  transition: border-color 0.2s ease;
+}
+
+.card-link a:hover {
+  border-color: rgba(60, 47, 36, 0.6);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 48px 20px 64px;
+  }
+
+  h1 {
+    margin-bottom: 36px;
+    letter-spacing: 0.28em;
+  }
+
+  .card {
+    padding: 28px 24px;
+  }
 }


### PR DESCRIPTION
## Summary
- adopt a warm neutral palette, typography, and spacing consistent with the mockup
- restyle the event cards with a grid layout, softened borders, and layered drop shadows
- render optional event links as anchors so missing data no longer displays `undefined`

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd9657cb488327b23fb251884ef695