### PR TITLE
Adjust mobile card layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -121,7 +121,19 @@ h1 {
     letter-spacing: 0.28em;
   }
 
+  #cards-container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 40px;
+  }
+
   .card {
-    padding: 28px 24px;
+    padding: 32px 24px;
+    min-height: calc(100vh - 140px);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- switch the mobile cards container to a single-column flex layout
- expand individual cards on small screens so they nearly fill the viewport

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0fec217048327929f24d43ccea7b1