### PR TITLE
Add Diesel Season 26 mockup HTML

### DIFF
--- a/dieselseason26_v01.html
+++ b/dieselseason26_v01.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diesel Season 26 – Mockup</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(
+            160% 120% at 15% 10%,
+            rgba(255, 255, 255, 0.85) 0%,
+            rgba(248, 246, 242, 0.92) 30%,
+            rgba(236, 233, 227, 0.98) 55%,
+            rgba(221, 215, 206, 1) 100%
+          ),
+          linear-gradient(135deg, #fdfcfa 0%, #e3ded4 100%);
+        background-blend-mode: soft-light, normal;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      .grid {
+        width: min(85vw, 880px);
+        display: grid;
+        grid-template-columns: repeat(3, minmax(180px, 1fr));
+        gap: clamp(28px, 4vw, 56px);
+        padding: clamp(24px, 5vw, 72px);
+      }
+
+      .card {
+        position: relative;
+        aspect-ratio: 3 / 4;
+        background:
+          radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.95), transparent 55%),
+          radial-gradient(
+            circle at 70% 75%,
+            rgba(248, 248, 248, 0.85),
+            rgba(243, 243, 243, 0.9) 45%,
+            rgba(235, 235, 235, 0.92) 100%
+          );
+        border-radius: 8px;
+        border: 1px solid rgba(255, 255, 255, 0.9);
+        box-shadow:
+          0 26px 45px rgba(0, 0, 0, 0.08),
+          0 16px 24px rgba(0, 0, 0, 0.05),
+          0 2px 6px rgba(0, 0, 0, 0.08);
+      }
+
+      .card::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0.65) 0%,
+            rgba(255, 255, 255, 0) 28%
+          ),
+          linear-gradient(0deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 42%);
+        mix-blend-mode: screen;
+        pointer-events: none;
+      }
+
+      @media (max-width: 760px) {
+        .grid {
+          grid-template-columns: repeat(2, minmax(140px, 1fr));
+        }
+      }
+
+      @media (max-width: 520px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="card" aria-hidden="true"></div>
+      <div class="card" aria-hidden="true"></div>
+      <div class="card" aria-hidden="true"></div>
+      <div class="card" aria-hidden="true"></div>
+      <div class="card" aria-hidden="true"></div>
+      <div class="card" aria-hidden="true"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create dieselseason26_v01.html to replicate the Diesel Season 26 card mockup
- implement gradient background, card shadows, and responsive grid layout inline in the document

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce67deaa3c8327a1f60e93356f949c