### PR TITLE
Add trio of 2026 event page mockups

### DIFF
--- a/mockup1.html
+++ b/mockup1.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diesel-Termine 2026 – Mockup 1</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --background: #f5f5f5;
+      --text: #1f1f1f;
+      --accent: #1d4ed8;
+      --card-bg: #ffffff;
+      --muted: #6b7280;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: #111827;
+        --text: #f9fafb;
+        --accent: #60a5fa;
+        --card-bg: #1f2937;
+        --muted: #9ca3af;
+      }
+    }
+    body {
+      margin: 0;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--background);
+      color: var(--text);
+    }
+    header {
+      padding: clamp(3rem, 6vw, 5rem) clamp(1.5rem, 4vw, 4rem);
+      text-align: center;
+      background: linear-gradient(135deg, rgba(29, 78, 216, 0.9), rgba(2, 132, 199, 0.85));
+      color: #fff;
+    }
+    header h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2.5rem, 5vw, 3.5rem);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    header p {
+      margin: 0;
+      font-size: clamp(1.05rem, 2.3vw, 1.25rem);
+      max-width: 45rem;
+      margin-inline: auto;
+    }
+    main {
+      padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 6vw, 6rem) 4rem;
+      display: grid;
+      gap: clamp(1.5rem, 3vw, 2.5rem);
+      background: var(--background);
+    }
+    .event-card {
+      background: var(--card-bg);
+      border-radius: 1.5rem;
+      padding: clamp(1.75rem, 4vw, 2.75rem);
+      box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.25);
+      display: grid;
+      gap: 1.25rem;
+    }
+    .event-card time {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--accent);
+      text-transform: uppercase;
+      letter-spacing: 0.15em;
+    }
+    .event-card h2 {
+      margin: 0;
+      font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+      letter-spacing: 0.02em;
+    }
+    .location {
+      display: grid;
+      gap: 0.35rem;
+      font-size: 1.05rem;
+      color: var(--muted);
+    }
+    .event-card a {
+      color: inherit;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      width: fit-content;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      background: rgba(29, 78, 216, 0.08);
+    }
+    .event-card a:hover,
+    .event-card a:focus {
+      background: rgba(29, 78, 216, 0.15);
+    }
+    footer {
+      padding: 3rem 1.5rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Diesel-Season 2026</h1>
+    <p>Vier Treffen, eine Leidenschaft – entdecke alle bestätigten Termine der Diesel-Szene 2026 auf einen Blick.</p>
+  </header>
+  <main>
+    <article class="event-card">
+      <time datetime="2026-06-04">04.–07. Juni 2026</time>
+      <h2>Big Knock</h2>
+      <div class="location">
+        <span>Care Ashore</span>
+        <span>Springbok Est · Dunsfold Rd</span>
+        <span>Alfold GU6 8EX (UK)</span>
+      </div>
+      <p>Ihr könnt schon ein paar Tage früher anreisen. Wir sind auf der Rückseite des Herrenhauses – im Uhrzeigersinn der Walled Garden Road folgen und bei den hohen Fichten einbiegen.</p>
+      <a href="http://www.dieselbike.net/" target="_blank" rel="noreferrer noopener">Website besuchen →</a>
+    </article>
+
+    <article class="event-card">
+      <time datetime="2026-07-11">11.–12. Juli 2026</time>
+      <h2>Bergrennen Gaschney</h2>
+      <div class="location">
+        <span>Muhlbach sur Munster (FR)</span>
+      </div>
+      <p>Course ZUE et Championnats de Suisse FHRM et SMLT: das historische Bergrennen lockt mit spektakulären Kehren und alpinem Panorama.</p>
+      <a href="https://www.nouveau-moto-club-de-munster.net/" target="_blank" rel="noreferrer noopener">Mehr erfahren →</a>
+    </article>
+
+    <article class="event-card">
+      <time datetime="2026-08-16">16. August 2026</time>
+      <h2>Sommer Dieseltreffen?</h2>
+      <div class="location">
+        <span>Geyern (DE)</span>
+      </div>
+      <p>Ein mögliches Sommertreffen in Geyern – sobald weitere Details vorliegen, aktualisieren wir diese Seite.</p>
+      <a href="http://sommerdiesel.de/" target="_blank" rel="noreferrer noopener">Zur Webseite →</a>
+    </article>
+
+    <article class="event-card">
+      <time datetime="2026-09-11">11.–13. September 2026</time>
+      <h2>Internationales Dieselmotorradtreffen</h2>
+      <div class="location">
+        <span>Zeltplatz Abenteuerland</span>
+        <span>34414 Warburg/Bonenburg (DE)</span>
+      </div>
+      <p>Gemeinsame Ausfahrten und eine Wanderung durch die ersten Herbstfarben bilden den Rahmen für das große internationale Treffen.</p>
+      <a href="#">Weitere Infos folgen →</a>
+    </article>
+  </main>
+  <footer>
+    Stand: April 2024 – alle Angaben ohne Gewähr. Änderungen werden hier laufend ergänzt.
+  </footer>
+</body>
+</html>

--- a/mockup2.html
+++ b/mockup2.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diesel-Season 2026 – Mockup 2</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Manrope", "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, #0f172a, #020617 55%);
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 8vw, 8rem) 2rem;
+    }
+    header p {
+      text-transform: uppercase;
+      letter-spacing: 0.4em;
+      font-size: 0.9rem;
+      color: rgba(148, 163, 184, 0.8);
+      margin: 0 0 1.5rem;
+    }
+    header h1 {
+      font-size: clamp(2.75rem, 8vw, 4.5rem);
+      margin: 0;
+      font-weight: 700;
+    }
+    header span {
+      display: block;
+      color: #38bdf8;
+    }
+    .timeline {
+      flex: 1;
+      display: grid;
+      place-items: center;
+      padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 5vw, 5rem) clamp(4rem, 8vw, 6rem);
+    }
+    .timeline ol {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      max-width: 800px;
+      width: min(90vw, 800px);
+      border-left: 2px solid rgba(56, 189, 248, 0.4);
+      position: relative;
+    }
+    .timeline li {
+      padding: 0 0 3rem 2rem;
+      position: relative;
+    }
+    .timeline li:last-child {
+      padding-bottom: 0;
+    }
+    .timeline li::before {
+      content: "";
+      position: absolute;
+      left: -11px;
+      top: 0.35rem;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 3px solid #020617;
+      background: #38bdf8;
+      box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.25);
+    }
+    .event-header {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.75rem;
+    }
+    .event-title {
+      font-size: clamp(1.6rem, 3vw, 2.2rem);
+      margin: 0;
+      font-weight: 600;
+    }
+    .event-date {
+      font-weight: 500;
+      color: #38bdf8;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .location {
+      margin: 0.75rem 0 0;
+      color: rgba(148, 163, 184, 0.9);
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+    .location span {
+      display: block;
+    }
+    .event-body {
+      margin: 1rem 0 0;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.92);
+    }
+    .event-link {
+      margin-top: 1.25rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.65rem 1.2rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.12);
+      color: #38bdf8;
+      text-decoration: none;
+      font-weight: 600;
+      transition: background 0.2s ease;
+    }
+    .event-link::after {
+      content: "→";
+      font-size: 1.1rem;
+      translate: 0 1px;
+    }
+    .event-link:hover,
+    .event-link:focus {
+      background: rgba(56, 189, 248, 0.22);
+    }
+    footer {
+      padding: 2rem;
+      text-align: center;
+      font-size: 0.85rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.8);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <p>Plan ahead</p>
+    <h1>Diesel Season <span>2026</span></h1>
+  </header>
+  <section class="timeline">
+    <ol>
+      <li>
+        <div class="event-header">
+          <p class="event-date">04.–07. Juni 2026</p>
+          <h2 class="event-title">Big Knock</h2>
+        </div>
+        <p class="location">
+          <span>Care Ashore · Springbok Est</span>
+          <span>Dunsfold Rd · Alfold GU6 8EX</span>
+          <span>Wir befinden uns hinter dem Haupthaus – folgt der Walled Garden Road im Uhrzeigersinn und biegt bei den hohen Fichten ein.</span>
+        </p>
+        <p class="event-body">Ein verlängertes Wochenende auf der Insel: Diesel-Fans aus ganz Europa treffen sich in der grünen Idylle von Surrey. Frühe Anreise ist willkommen.</p>
+        <a class="event-link" href="http://www.dieselbike.net/" target="_blank" rel="noreferrer noopener">Eventseite</a>
+      </li>
+      <li>
+        <div class="event-header">
+          <p class="event-date">11.–12. Juli 2026</p>
+          <h2 class="event-title">Bergrennen Gaschney</h2>
+        </div>
+        <p class="location">
+          <span>Muhlbach sur Munster</span>
+          <span>Course ZUE und Schweizer Meisterschaften FHRM &amp; SMLT.</span>
+        </p>
+        <p class="event-body">Historische Maschinen und moderne Diesel-Umbauten kämpfen sich die Serpentinen hinauf – ein Pflichttermin für Speed-Fans mit Benzin (und Diesel) im Blut.</p>
+        <a class="event-link" href="https://www.nouveau-moto-club-de-munster.net/" target="_blank" rel="noreferrer noopener">Programm</a>
+      </li>
+      <li>
+        <div class="event-header">
+          <p class="event-date">16. August 2026</p>
+          <h2 class="event-title">Sommer Dieseltreffen?</h2>
+        </div>
+        <p class="location">
+          <span>Geyern</span>
+        </p>
+        <p class="event-body">Das mögliche Sommertreffen in Mittelfranken – sobald das Go kommt, sind wir bereit. Trage dir das Datum schon einmal ein.</p>
+        <a class="event-link" href="http://sommerdiesel.de/" target="_blank" rel="noreferrer noopener">Zur Webseite</a>
+      </li>
+      <li>
+        <div class="event-header">
+          <p class="event-date">11.–13. September 2026</p>
+          <h2 class="event-title">Internationales Dieselmotorradtreffen</h2>
+        </div>
+        <p class="location">
+          <span>Zeltplatz Abenteuerland · 34414 Warburg/Bonenburg</span>
+        </p>
+        <p class="event-body">Ein Wochenende in den ersten Herbstfarben: Ausfahrten, Lagerfeuer und eine gemeinsame Wanderung bilden den Rahmen des großen Saisonfinales.</p>
+        <a class="event-link" href="#" aria-disabled="true">Details folgen</a>
+      </li>
+    </ol>
+  </section>
+  <footer>
+    Stand: April 2024 – Änderungen vorbehalten.
+  </footer>
+</body>
+</html>

--- a/mockup3.html
+++ b/mockup3.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diesel-Season 2026 – Mockup 3</title>
+  <style>
+    :root {
+      --bg: #f7f7f7;
+      --text: #0f172a;
+      --accent: #22c55e;
+      --accent-muted: rgba(34, 197, 94, 0.15);
+      --muted: #64748b;
+      --card: #ffffff;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Satoshi", "Helvetica Neue", Arial, sans-serif;
+      background: linear-gradient(120deg, #eef2ff 0%, #fdf2f8 35%, #f7fee7 100%);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      padding: clamp(2.5rem, 4vw, 4rem) clamp(1.5rem, 6vw, 6rem);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    header h1 {
+      margin: 0;
+      font-size: clamp(2.4rem, 6vw, 3.8rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    header p {
+      max-width: 45ch;
+      font-size: clamp(1.05rem, 2.3vw, 1.25rem);
+      color: var(--muted);
+      line-height: 1.6;
+      margin: 0;
+    }
+    .grid {
+      flex: 1;
+      display: grid;
+      gap: clamp(1.5rem, 3vw, 3rem);
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      padding: clamp(2rem, 5vw, 5rem) clamp(1.5rem, 6vw, 6rem) clamp(4rem, 10vw, 6rem);
+    }
+    .event {
+      background: var(--card);
+      border-radius: 1.75rem;
+      padding: clamp(1.75rem, 3vw, 2.5rem);
+      display: grid;
+      gap: 1.1rem;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 35px 60px -35px rgba(15, 23, 42, 0.35);
+      border: 1px solid rgba(15, 23, 42, 0.06);
+    }
+    .event::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, transparent 20%, rgba(34, 197, 94, 0.08));
+      pointer-events: none;
+    }
+    .event time {
+      font-size: 0.95rem;
+      letter-spacing: 0.3em;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: var(--muted);
+    }
+    .event h2 {
+      margin: 0;
+      font-size: clamp(1.6rem, 3vw, 2.1rem);
+      font-weight: 600;
+    }
+    .event .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--accent);
+      padding: 0.4rem 0.9rem;
+      border-radius: 999px;
+      background: var(--accent-muted);
+      width: fit-content;
+    }
+    .location {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.6;
+      display: grid;
+      gap: 0.25rem;
+    }
+    .event p {
+      margin: 0;
+      line-height: 1.7;
+    }
+    .links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+    .links a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.55rem 1rem;
+      border-radius: 999px;
+      border: 1px solid rgba(15, 23, 42, 0.15);
+      text-decoration: none;
+      color: inherit;
+      transition: transform 0.2s ease, border-color 0.2s ease;
+      background: rgba(255, 255, 255, 0.75);
+      backdrop-filter: blur(4px);
+    }
+    .links a:hover,
+    .links a:focus {
+      transform: translateY(-2px);
+      border-color: rgba(34, 197, 94, 0.5);
+    }
+    footer {
+      padding: 2rem 1.5rem 3rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Vier Highlights der Diesel-Community</h1>
+    <p>Eine farbenfrohe Übersicht der geplanten Treffen 2026 – ideal für eine Landingpage oder Social-Media-Teaser.</p>
+  </header>
+  <section class="grid">
+    <article class="event">
+      <span class="tag">Season Start</span>
+      <time datetime="2026-06-04">04.–07.06.2026</time>
+      <h2>Big Knock · Care Ashore</h2>
+      <p class="location">
+        <span>Springbok Est, Dunsfold Rd</span>
+        <span>Alfold GU6 8EX</span>
+        <span>Hinweis: Wir befinden uns auf der rückwärtigen Seite des Haupthauses – der Walled Garden Road folgen und bei den hohen Fichten einbiegen.</span>
+      </p>
+      <p>Verlängertes Wochenende in Surrey: lockere Atmosphäre, viel Austausch und Diesel-Nerdtalk bis spät in die Nacht.</p>
+      <div class="links">
+        <a href="http://www.dieselbike.net/" target="_blank" rel="noreferrer noopener">Website</a>
+      </div>
+    </article>
+
+    <article class="event">
+      <span class="tag">Motorsport</span>
+      <time datetime="2026-07-11">11.–12.07.2026</time>
+      <h2>Bergrennen Gaschney</h2>
+      <p class="location">
+        <span>Muhlbach sur Munster</span>
+        <span>Course ZUE · Championnats de Suisse FHRM &amp; SMLT</span>
+      </p>
+      <p>Ein Wochenende voller Kehren, Höhenmeter und Zweirad-Historie – perfekter Schauplatz für Diesel-Umbauten mit Racing-Genen.</p>
+      <div class="links">
+        <a href="https://www.nouveau-moto-club-de-munster.net/" target="_blank" rel="noreferrer noopener">Eventseite</a>
+      </div>
+    </article>
+
+    <article class="event">
+      <span class="tag">Community</span>
+      <time datetime="2026-08-16">16.08.2026</time>
+      <h2>Sommer Dieseltreffen?</h2>
+      <p class="location">
+        <span>Geyern</span>
+      </p>
+      <p>Noch in Planung, aber schon im Kalender markiert: das mögliche Sommerevent für alle, die es entspannt mögen.</p>
+      <div class="links">
+        <a href="http://sommerdiesel.de/" target="_blank" rel="noreferrer noopener">Infos</a>
+      </div>
+    </article>
+
+    <article class="event">
+      <span class="tag">Season Finale</span>
+      <time datetime="2026-09-11">11.–13.09.2026</time>
+      <h2>Internationales Dieselmotorradtreffen</h2>
+      <p class="location">
+        <span>Zeltplatz Abenteuerland</span>
+        <span>34414 Warburg/Bonenburg</span>
+      </p>
+      <p>Wanderung durch die ersten Herbstfarben, gemeinsame Ausfahrten und Lagerfeuer: das große Finale der Saison.</p>
+      <div class="links">
+        <a href="#">Details folgen</a>
+      </div>
+    </article>
+  </section>
+  <footer>
+    Letzte Aktualisierung: April 2024 · Alle Angaben ohne Gewähr.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mockup1.html with a clean card-based layout for the 2026 Diesel season events
- add mockup2.html presenting the event details on a neon timeline concept
- add mockup3.html featuring a colorful grid of event highlight cards

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1059646dc83279316256a6425b933