### PR TITLE
Add trio of 2026 event page mockups

### DIFF
--- a/mockup1.html
+++ b/mockup1.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diesel Termine 2026 – Mockup 1</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      background: #f8f8f4;
+      color: #222;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      display: flex;
+      justify-content: center;
+      min-height: 100vh;
+    }
+
+    main {
+      max-width: 900px;
+      padding: 4rem 1.5rem 5rem;
+    }
+
+    header {
+      margin-bottom: 3rem;
+    }
+
+    header h1 {
+      margin: 0 0 0.5rem;
+      font-size: clamp(2.5rem, 5vw, 3.5rem);
+      font-weight: 700;
+    }
+
+    header p {
+      margin: 0;
+      font-size: 1.15rem;
+      color: #555;
+    }
+
+    .timeline {
+      position: relative;
+      margin-left: 1rem;
+      padding-left: 1.5rem;
+      border-left: 2px solid #d0d0c9;
+    }
+
+    article {
+      padding: 1.5rem 1.5rem 1.5rem 2.5rem;
+      margin-bottom: 2.5rem;
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 12px;
+      box-shadow: 0 10px 25px rgba(33, 37, 41, 0.08);
+      position: relative;
+    }
+
+    article::before {
+      content: "";
+      position: absolute;
+      width: 14px;
+      height: 14px;
+      background: #2c6e49;
+      border-radius: 50%;
+      left: -2.5rem;
+      top: 1.5rem;
+      box-shadow: 0 0 0 4px #f8f8f4;
+    }
+
+    h2 {
+      margin: 0 0 0.25rem;
+      font-size: 1.75rem;
+      color: #2c6e49;
+    }
+
+    .subtitle {
+      font-size: 1.1rem;
+      color: #444;
+      margin-bottom: 1rem;
+    }
+
+    .meta {
+      display: grid;
+      gap: 0.25rem;
+      font-size: 0.95rem;
+      color: #333;
+    }
+
+    .meta span {
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      color: #777;
+    }
+
+    address {
+      font-style: normal;
+      line-height: 1.4;
+      margin-bottom: 1rem;
+    }
+
+    a {
+      color: #2c6e49;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 600px) {
+      main {
+        padding: 3rem 1rem 4rem;
+      }
+
+      article {
+        padding: 1.25rem 1.25rem 1.25rem 2rem;
+      }
+
+      article::before {
+        left: -2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Diesel Termine 2026</h1>
+      <p>Vier Highlights für Diesel-Enthusiast:innen im kommenden Jahr im Überblick.</p>
+    </header>
+
+    <section class="timeline">
+      <article>
+        <h2>Diesel-Season 2026</h2>
+        <div class="subtitle">Big Knock · 04.–07.06.2026</div>
+        <address>
+          Care Ashore<br />
+          Springbok Est<br />
+          Dunsfold Rd<br />
+          Alfold GU6 8EX
+        </address>
+        <p>Anreise einige Tage früher möglich. Der Treffpunkt befindet sich auf der Rückseite des Haupthauses – im Uhrzeigersinn entlang der Walled-Garden-Straße und bei den hohen Tannen einbiegen.</p>
+        <p><a href="http://www.dieselbike.net/" target="_blank" rel="noopener">Weitere Informationen</a></p>
+      </article>
+
+      <article>
+        <h2>Bergrennen Gaschney</h2>
+        <div class="subtitle">11.–12.07.2026</div>
+        <address>
+          Muhlbach sur Munster
+        </address>
+        <p>Course ZUE et Championnats de Suisse FHRM et SMLT.</p>
+        <p><a href="https://www.nouveau-moto-club-de-munster.net/" target="_blank" rel="noopener">Offizielle Seite</a></p>
+      </article>
+
+      <article>
+        <h2>Sommer Dieseltreffen?</h2>
+        <div class="subtitle">16. August 2026</div>
+        <address>
+          Geyern
+        </address>
+        <p>Weitere Informationen folgen, sobald Details bestätigt sind.</p>
+        <p><a href="http://sommerdiesel.de/" target="_blank" rel="noopener">Zur Webseite</a></p>
+      </article>
+
+      <article>
+        <h2>Internationales Dieselmotorradtreffen 2026</h2>
+        <div class="subtitle">11.–13.09.2026</div>
+        <address>
+          Zeltplatz Abenteuerland<br />
+          34414 Warburg/Bonenburg
+        </address>
+        <p>Wanderung durch die ersten Herbstfarben und entspanntes Zusammensein zum Saisonabschluss.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/mockup2.html
+++ b/mockup2.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diesel Termine 2026 – Mockup 2</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Work Sans", "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, #f3f6fb, #e7ecf3 55%, #dae2ec 100%);
+      color: #0f1b2c;
+      min-height: 100vh;
+    }
+
+    header {
+      text-align: center;
+      padding: 4rem 1.5rem 2.5rem;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2.25rem, 6vw, 3.8rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    header p {
+      margin: 0.75rem auto 0;
+      max-width: 40ch;
+      font-size: 1.05rem;
+      color: rgba(15, 27, 44, 0.7);
+    }
+
+    .grid {
+      display: grid;
+      gap: 2rem;
+      padding: 0 1.5rem 4rem;
+      max-width: 1100px;
+      margin: 0 auto;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    article {
+      background: #fff;
+      border-radius: 22px;
+      padding: 2.25rem 2rem 2.5rem;
+      box-shadow: 0 20px 45px -20px rgba(7, 25, 53, 0.35);
+      position: relative;
+      overflow: hidden;
+    }
+
+    article::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(46, 140, 196, 0.12), rgba(87, 90, 140, 0.2));
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      pointer-events: none;
+    }
+
+    article:hover::after {
+      opacity: 1;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 1.5rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .date {
+      margin-top: 0.8rem;
+      font-size: 1rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgba(15, 27, 44, 0.6);
+    }
+
+    .location {
+      margin: 1.4rem 0 1.1rem;
+      font-style: normal;
+      line-height: 1.5;
+      font-weight: 500;
+    }
+
+    p {
+      margin: 0 0 1.2rem;
+      line-height: 1.6;
+    }
+
+    a {
+      font-weight: 600;
+      color: #1f5aa6;
+      text-decoration: none;
+      letter-spacing: 0.04em;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 1rem 3rem;
+      color: rgba(15, 27, 44, 0.6);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Diesel Rendezvous 2026</h1>
+    <p>Vier Orte, ein gemeinsamer Sound: Entdecke die Höhepunkte der Diesel-Community im kommenden Jahr.</p>
+  </header>
+
+  <section class="grid">
+    <article>
+      <h2>Diesel-Season 2026</h2>
+      <div class="date">Big Knock · 04.–07.06.2026</div>
+      <address class="location">
+        Care Ashore<br />
+        Springbok Est<br />
+        Dunsfold Rd<br />
+        Alfold GU6 8EX
+      </address>
+      <p>You can arrive a few days early. Wir treffen uns auf der abgewandten Seite des Haupthauses – im Uhrzeigersinn entlang der Walled Garden Road, bei den hohen Tannen einbiegen.</p>
+      <a href="http://www.dieselbike.net/" target="_blank" rel="noopener">dieselbike.net</a>
+    </article>
+
+    <article>
+      <h2>Bergrennen Gaschney</h2>
+      <div class="date">11.–12.07.2026</div>
+      <address class="location">
+        Muhlbach sur Munster
+      </address>
+      <p>Course ZUE et Championnats de Suisse FHRM et SMLT.</p>
+      <a href="https://www.nouveau-moto-club-de-munster.net/" target="_blank" rel="noopener">nouveau-moto-club-de-munster.net</a>
+    </article>
+
+    <article>
+      <h2>Sommer Dieseltreffen?</h2>
+      <div class="date">16. August 2026</div>
+      <address class="location">
+        Geyern
+      </address>
+      <p>Ein offenes Sommerevent – sobald Details feststehen, wird hier aktualisiert.</p>
+      <a href="http://sommerdiesel.de/" target="_blank" rel="noopener">sommerdiesel.de</a>
+    </article>
+
+    <article>
+      <h2>Internationales Dieselmotorradtreffen</h2>
+      <div class="date">11.–13.09.2026</div>
+      <address class="location">
+        Zeltplatz Abenteuerland<br />
+        34414 Warburg/Bonenburg
+      </address>
+      <p>Wanderung durch die ersten Herbstfarben – perfekter Ausklang einer kraftvollen Saison.</p>
+    </article>
+  </section>
+
+  <footer>
+    Plane jetzt deine Saison &ndash; wir sehen uns vor Ort!
+  </footer>
+</body>
+</html>

--- a/mockup3.html
+++ b/mockup3.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diesel Termine 2026 – Mockup 3</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", Arial, sans-serif;
+      color: #1a1a1a;
+      background: #101820;
+      background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+        linear-gradient(225deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+        linear-gradient(45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%);
+      background-size: 30px 30px;
+      background-position: 0 0, 0 15px, 15px -15px, -15px 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 3rem 1.25rem 4rem;
+    }
+
+    header {
+      text-align: center;
+      max-width: 780px;
+      color: #f7f8f8;
+      margin-bottom: 3rem;
+    }
+
+    header h1 {
+      margin: 0 0 0.75rem;
+      font-size: clamp(2.8rem, 7vw, 4.2rem);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    header p {
+      margin: 0;
+      font-size: 1.1rem;
+      color: rgba(247, 248, 248, 0.7);
+      line-height: 1.6;
+    }
+
+    .list {
+      width: min(1050px, 100%);
+      display: grid;
+      gap: 1.75rem;
+    }
+
+    article {
+      background: rgba(247, 248, 248, 0.07);
+      border: 1px solid rgba(247, 248, 248, 0.12);
+      border-radius: 16px;
+      padding: 2rem;
+      color: #f1f3f4;
+      backdrop-filter: blur(8px);
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .header {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem 2rem;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    .header h2 {
+      margin: 0;
+      font-size: 1.75rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .date {
+      font-size: 0.95rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: rgba(247, 248, 248, 0.6);
+    }
+
+    address {
+      font-style: normal;
+      line-height: 1.6;
+      font-size: 1rem;
+      color: rgba(247, 248, 248, 0.85);
+    }
+
+    p {
+      margin: 0;
+      line-height: 1.6;
+      color: rgba(247, 248, 248, 0.78);
+    }
+
+    a {
+      justify-self: flex-start;
+      padding: 0.65rem 1.1rem;
+      border-radius: 999px;
+      background: linear-gradient(120deg, #49b675, #2ea271);
+      color: #101820;
+      font-weight: 600;
+      text-decoration: none;
+      letter-spacing: 0.05em;
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
+    }
+
+    a:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 25px rgba(73, 182, 117, 0.35);
+    }
+
+    .note {
+      font-size: 0.9rem;
+      color: rgba(247, 248, 248, 0.5);
+      text-align: center;
+      margin-top: 3rem;
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 2.5rem 1rem 3rem;
+      }
+
+      article {
+        padding: 1.6rem;
+      }
+
+      .header h2 {
+        font-size: 1.4rem;
+      }
+
+      .date {
+        letter-spacing: 0.16em;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Diesel Agenda 2026</h1>
+    <p>Vier Stopps zwischen Frühsommer und Herbst – für alle, die Diesel im Herzen tragen.</p>
+  </header>
+
+  <section class="list">
+    <article>
+      <div class="header">
+        <h2>Diesel-Season 2026 – Big Knock</h2>
+        <div class="date">04.–07.06.2026</div>
+      </div>
+      <address>
+        Care Ashore<br />
+        Springbok Est<br />
+        Dunsfold Rd<br />
+        Alfold GU6 8EX
+      </address>
+      <p>You can arrive a few days early. Wir befinden uns auf der Rückseite des Haupthauses – im Uhrzeigersinn durch den Mauergarten und bei den hohen Tannen einbiegen.</p>
+      <a href="http://www.dieselbike.net/" target="_blank" rel="noopener">Event-Webseite</a>
+    </article>
+
+    <article>
+      <div class="header">
+        <h2>Bergrennen Gaschney</h2>
+        <div class="date">11.–12.07.2026</div>
+      </div>
+      <address>
+        Muhlbach sur Munster
+      </address>
+      <p>Course ZUE et Championnats de Suisse FHRM et SMLT.</p>
+      <a href="https://www.nouveau-moto-club-de-munster.net/" target="_blank" rel="noopener">Zur Seite</a>
+    </article>
+
+    <article>
+      <div class="header">
+        <h2>Sommer Dieseltreffen?</h2>
+        <div class="date">16. August 2026</div>
+      </div>
+      <address>
+        Geyern
+      </address>
+      <p>Locker geplant – sobald Programm und Ablauf stehen, folgen Details.</p>
+      <a href="http://sommerdiesel.de/" target="_blank" rel="noopener">Mehr erfahren</a>
+    </article>
+
+    <article>
+      <div class="header">
+        <h2>Internationales Dieselmotorradtreffen</h2>
+        <div class="date">11.–13.09.2026</div>
+      </div>
+      <address>
+        Zeltplatz Abenteuerland<br />
+        34414 Warburg/Bonenburg
+      </address>
+      <p>Wanderung durch die ersten Herbstfarben – gemeinsamer Saisonabschluss mit Diesel-Community aus ganz Europa.</p>
+    </article>
+  </section>
+
+  <div class="note">Speichere die Termine &ndash; Updates folgen, sobald neue Details eintreffen.</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create mockup1.html with vertical timeline layout for four diesel events in 2026
- add mockup2.html showing the events as cards on a soft gradient background
- add mockup3.html with a glassmorphism-inspired dark theme presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1059646dc83279316256a6425b933