### PR TITLE
Add three mockup designs for 2026 diesel events

### DIFF
--- a/mockup1.html
+++ b/mockup1.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diesel-Termine 2026 – Mockup 1</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      --accent: #2d6a4f;
+      --muted: #4a4a4a;
+      --bg: #f5f5f5;
+      --card-bg: #ffffff;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: #1a1a1a;
+    }
+
+    header {
+      background: linear-gradient(135deg, var(--accent), #52b788);
+      color: #fff;
+      padding: 4rem 1.5rem 3rem;
+      text-align: center;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2.4rem, 4vw, 3.4rem);
+      letter-spacing: 0.05em;
+    }
+
+    header p {
+      max-width: 34rem;
+      margin: 1.5rem auto 0;
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+
+    main {
+      max-width: 900px;
+      margin: -2rem auto 4rem;
+      padding: 0 1.5rem;
+    }
+
+    .event-list {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .event {
+      background: var(--card-bg);
+      border-radius: 14px;
+      padding: 1.75rem;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .event:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.12);
+    }
+
+    .event h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1.6rem;
+      color: var(--accent);
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem 2.5rem;
+      margin-bottom: 1.1rem;
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
+    .meta span {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .event address {
+      font-style: normal;
+      line-height: 1.5;
+      margin-bottom: 1rem;
+    }
+
+    .event p {
+      margin: 0 0 0.9rem;
+      line-height: 1.6;
+    }
+
+    .event a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .event a:hover {
+      text-decoration: underline;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 1.5rem 3rem;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Diesel-Events 2026</h1>
+    <p>Vier handverlesene Termine für Diesel-Fans im kommenden Jahr. Perfekt zum Planen, Treffen und Unterwegssein.</p>
+  </header>
+  <main>
+    <section class="event-list">
+      <article class="event">
+        <h2>Diesel-Season 2026 – Big Knock</h2>
+        <div class="meta">
+          <span>04.–07. Juni 2026</span>
+          <span>Care Ashore, Springbok Est, Dunsfold Rd, Alfold GU6 8EX</span>
+        </div>
+        <address>
+          You can arrive a few days early. We are on the far side of the main house – clockwise round the walled Garden road &amp; turn in by the tall fir trees.
+        </address>
+        <a href="http://www.dieselbike.net/">www.dieselbike.net</a>
+      </article>
+
+      <article class="event">
+        <h2>Bergrennen Gaschney</h2>
+        <div class="meta">
+          <span>11.–12. Juli 2026</span>
+          <span>Muhlbach sur Munster</span>
+        </div>
+        <p>Course ZUE et Championnats de Suisse FHRM et SMLT.</p>
+        <a href="https://www.nouveau-moto-club-de-munster.net/">nouveau-moto-club-de-munster.net</a>
+      </article>
+
+      <article class="event">
+        <h2>Sommer Dieseltreffen?</h2>
+        <div class="meta">
+          <span>16. August 2026</span>
+          <span>Geyern</span>
+        </div>
+        <a href="http://sommerdiesel.de/">sommerdiesel.de</a>
+      </article>
+
+      <article class="event">
+        <h2>Internationales Dieselmotorradtreffen 2026</h2>
+        <div class="meta">
+          <span>11.–13. September 2026</span>
+          <span>Zeltplatz Abenteuerland, 34414 Warburg/Bonenburg</span>
+        </div>
+        <p>Wanderung durch die ersten Herbstfarben.</p>
+      </article>
+    </section>
+  </main>
+  <footer>
+    © 2026 Diesel-Community. Alle Angaben ohne Gewähr.
+  </footer>
+</body>
+</html>

--- a/mockup2.html
+++ b/mockup2.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diesel-Termine 2026 – Mockup 2</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 4rem 1.5rem 2rem;
+      text-align: center;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2.2rem, 4vw, 3.2rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    header p {
+      margin: 1.25rem auto 0;
+      max-width: 32rem;
+      line-height: 1.6;
+      color: rgba(226, 232, 240, 0.8);
+    }
+
+    main {
+      flex: 1;
+      padding: 0 1.5rem 4rem;
+    }
+
+    .grid {
+      display: grid;
+      gap: 1.75rem;
+      max-width: 1100px;
+      margin: 0 auto;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .card {
+      background: rgba(15, 23, 42, 0.72);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 16px;
+      padding: 1.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      backdrop-filter: blur(8px);
+      transition: border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .card:hover {
+      border-color: rgba(129, 140, 248, 0.6);
+      transform: translateY(-6px);
+    }
+
+    .card h2 {
+      margin: 0;
+      font-size: 1.35rem;
+      color: #60a5fa;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      background: rgba(96, 165, 250, 0.15);
+      color: #bae6fd;
+      padding: 0.4rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    .location {
+      font-size: 0.95rem;
+      color: rgba(226, 232, 240, 0.72);
+      line-height: 1.5;
+    }
+
+    .details {
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: rgba(226, 232, 240, 0.82);
+    }
+
+    .card a {
+      margin-top: auto;
+      align-self: flex-start;
+      color: #a5b4fc;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .card a:hover {
+      text-decoration: underline;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 1.5rem 3rem;
+      font-size: 0.85rem;
+      color: rgba(148, 163, 184, 0.7);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Diesel Agenda 2026</h1>
+    <p>Ein eleganter Überblick über vier Szene-Highlights zwischen Juni und September 2026.</p>
+  </header>
+  <main>
+    <section class="grid">
+      <article class="card">
+        <span class="tag">04.–07.06.</span>
+        <h2>Diesel-Season 2026 – Big Knock</h2>
+        <p class="location">Care Ashore, Springbok Est, Dunsfold Rd, Alfold GU6 8EX</p>
+        <p class="details">Frühzeitige Anreise möglich. Treffpunkt auf der Rückseite des Haupthauses – dem Rundweg am ummauerten Garten folgen und bei den hohen Tannen einbiegen.</p>
+        <a href="http://www.dieselbike.net/">Website öffnen</a>
+      </article>
+
+      <article class="card">
+        <span class="tag">11.–12.07.</span>
+        <h2>Bergrennen Gaschney</h2>
+        <p class="location">Muhlbach sur Munster</p>
+        <p class="details">Course ZUE et Championnats de Suisse FHRM et SMLT.</p>
+        <a href="https://www.nouveau-moto-club-de-munster.net/">Website öffnen</a>
+      </article>
+
+      <article class="card">
+        <span class="tag">16.08.</span>
+        <h2>Sommer Dieseltreffen?</h2>
+        <p class="location">Geyern</p>
+        <a href="http://sommerdiesel.de/">Website öffnen</a>
+      </article>
+
+      <article class="card">
+        <span class="tag">11.–13.09.</span>
+        <h2>Internationales Dieselmotorradtreffen 2026</h2>
+        <p class="location">Zeltplatz Abenteuerland, 34414 Warburg/Bonenburg</p>
+        <p class="details">Wanderung durch die ersten Herbstfarben.</p>
+      </article>
+    </section>
+  </main>
+  <footer>
+    Planungshilfe für Diesel-Fans – Version Mockup 2.
+  </footer>
+</body>
+</html>

--- a/mockup3.html
+++ b/mockup3.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diesel-Termine 2026 – Mockup 3</title>
+  <style>
+    :root {
+      font-family: "Source Sans Pro", sans-serif;
+      background: #fff;
+      color: #212529;
+      --line: #ced4da;
+      --accent: #ff7b54;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: linear-gradient(180deg, rgba(255, 245, 235, 0.8), rgba(255, 255, 255, 1));
+    }
+
+    header {
+      padding: 3.5rem 1.5rem 2rem;
+      text-align: center;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 3rem);
+      color: #d9480f;
+      letter-spacing: 0.04em;
+    }
+
+    header p {
+      margin: 1rem auto 0;
+      max-width: 30rem;
+      line-height: 1.5;
+    }
+
+    main {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      padding: 0 1rem 4rem;
+    }
+
+    .timeline {
+      position: relative;
+      width: min(800px, 100%);
+      padding: 1rem 0 3rem;
+    }
+
+    .timeline::before {
+      content: "";
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      top: 0;
+      bottom: 2rem;
+      width: 2px;
+      background: var(--line);
+    }
+
+    .entry {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 2rem;
+      align-items: center;
+      margin-bottom: 3rem;
+    }
+
+    .entry:last-child {
+      margin-bottom: 0;
+    }
+
+    .entry:nth-child(even) .content {
+      order: -1;
+      text-align: right;
+    }
+
+    .marker {
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: #fff;
+      border: 4px solid var(--accent);
+    }
+
+    .date {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #495057;
+    }
+
+    .title {
+      font-size: 1.35rem;
+      margin: 0.4rem 0;
+      color: #e8590c;
+    }
+
+    .location {
+      margin: 0;
+      font-size: 0.95rem;
+      color: #495057;
+    }
+
+    .note {
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: #343a40;
+    }
+
+    .link {
+      margin-top: 0.75rem;
+      font-size: 0.9rem;
+      color: #d9480f;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .link:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 680px) {
+      .timeline::before {
+        left: 0.5rem;
+      }
+
+      .entry {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+        padding-left: 2.5rem;
+      }
+
+      .entry:nth-child(even) .content {
+        order: initial;
+        text-align: left;
+      }
+
+      .marker {
+        left: 0.5rem;
+        transform: translateX(-50%);
+      }
+    }
+
+    footer {
+      text-align: center;
+      padding: 1.5rem 1rem 2.5rem;
+      font-size: 0.85rem;
+      color: #868e96;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Terminfaden 2026</h1>
+    <p>Ein warmer, freundlicher Zeitstrahl, der alle Diesel-Begegnungen des Jahres zusammenführt.</p>
+  </header>
+  <main>
+    <section class="timeline">
+      <article class="entry">
+        <span class="marker" aria-hidden="true"></span>
+        <div class="date">04.–07. Juni 2026</div>
+        <div class="content">
+          <h2 class="title">Diesel-Season 2026 – Big Knock</h2>
+          <p class="location">Care Ashore, Springbok Est, Dunsfold Rd, Alfold GU6 8EX</p>
+          <p class="note">Anreise ein paar Tage früher ist willkommen. Orientierung: rechts herum um den ummauerten Garten und bei den hohen Tannen einbiegen.</p>
+          <a class="link" href="http://www.dieselbike.net/">www.dieselbike.net</a>
+        </div>
+      </article>
+
+      <article class="entry">
+        <span class="marker" aria-hidden="true"></span>
+        <div class="date">11.–12. Juli 2026</div>
+        <div class="content">
+          <h2 class="title">Bergrennen Gaschney</h2>
+          <p class="location">Muhlbach sur Munster</p>
+          <p class="note">Course ZUE et Championnats de Suisse FHRM et SMLT.</p>
+          <a class="link" href="https://www.nouveau-moto-club-de-munster.net/">Event-Website</a>
+        </div>
+      </article>
+
+      <article class="entry">
+        <span class="marker" aria-hidden="true"></span>
+        <div class="date">16. August 2026</div>
+        <div class="content">
+          <h2 class="title">Sommer Dieseltreffen?</h2>
+          <p class="location">Geyern</p>
+          <a class="link" href="http://sommerdiesel.de/">Event-Website</a>
+        </div>
+      </article>
+
+      <article class="entry">
+        <span class="marker" aria-hidden="true"></span>
+        <div class="date">11.–13. September 2026</div>
+        <div class="content">
+          <h2 class="title">Internationales Dieselmotorradtreffen 2026</h2>
+          <p class="location">Zeltplatz Abenteuerland, 34414 Warburg/Bonenburg</p>
+          <p class="note">Wanderung durch die ersten Herbstfarben.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+  <footer>
+    Konzeptstudie Mockup 3 – erstellt für die Diesel-Community 2026.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mockup1.html with luftiges Kartenlayout und Fokus auf weiche Schatten
- add mockup2.html mit dunklem Glas-Look und Karten im Raster
- add mockup3.html als Timeline-Konzept für die vier Termine

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e1059646dc83279316256a6425b933